### PR TITLE
Delete trainer on dex

### DIFF
--- a/app/views/pocket_monsters/index.html.erb
+++ b/app/views/pocket_monsters/index.html.erb
@@ -7,6 +7,8 @@
   <%= button_to "I Want a New Pokemon", { action: "create" }, { form_class: 'random_pokemon', remote: true }%>
 
   <%= button_to "Sort Pokemon", {}, { form_class: 'sort-pokemon'} %>
+
+  <%= link_to "I'm a Magikarp. I want out.", trainer_path(@trainer), method: "delete", id: "quit", data: { confirm: "Are you sure you want to leave the Pokémon League and delete your account?" } %>
   
   <div id="all-entries" >
     <% @trainer.pocket_monsters.sort_by { |pokemon| pokemon.species_id }.each do |pokemon| %>
@@ -15,8 +17,6 @@
   </div>
 
 </div>
-
-<%= link_to "I'm a Magikarp. I want out.", trainer_path(@trainer), method: "delete", id: "quit", data: { confirm: "Are you sure you want to leave the Pokémon League and delete your account?" } %>
 
 <!-- <audio loop id="background_audio" autoplay="autoplay">
   <source src="/assets/sound/trainer_profile.mp3" type="audio/mpeg" />

--- a/app/views/pocket_monsters/index.html.erb
+++ b/app/views/pocket_monsters/index.html.erb
@@ -16,6 +16,8 @@
 
 </div>
 
+<%= link_to "I'm a Magikarp. I want out.", trainer_path(@trainer), method: "delete", id: "quit", data: { confirm: "Are you sure you want to leave the Pokémon League and delete your account?" } %>
+
 <!-- <audio loop id="background_audio" autoplay="autoplay">
   <source src="/assets/sound/trainer_profile.mp3" type="audio/mpeg" />
 </audio> -->

--- a/spec/features/trainer_spec.rb
+++ b/spec/features/trainer_spec.rb
@@ -59,5 +59,14 @@ feature 'Trainer' do
         page.driver.browser.switch_to.alert.accept
         current_path.should eq(root_path)
     end
+
+    scenario "shouldn't allow user to leave league on Pokedex page without confirmation", js: true do
+        Trainer.create(name: "Gary")
+        visit(trainer_choose_starter_path(Trainer.last.id))
+        click_link("Bulbasaur")
+        click_link("I'm a Magikarp. I want out.")
+        page.driver.browser.switch_to.alert.dismiss
+        current_path.should eq(trainer_pocket_monsters_path(Trainer.last.id))
+    end
   end
 end

--- a/spec/features/trainer_spec.rb
+++ b/spec/features/trainer_spec.rb
@@ -50,5 +50,14 @@ feature 'Trainer' do
       page.driver.browser.switch_to.alert.dismiss
       current_path.should eq(trainer_choose_starter_path(Trainer.last.id))
     end
+
+    scenario "should allow user to leave league on Pokedex page with confirmation", js: true do
+        Trainer.create(name: "Gary")
+        visit(trainer_choose_starter_path(Trainer.last.id))
+        click_link("Bulbasaur")
+        click_link("I'm a Magikarp. I want out.")
+        page.driver.browser.switch_to.alert.accept
+        current_path.should eq(root_path)
+    end
   end
 end


### PR DESCRIPTION
We'll need to talk about where we want this link to go. I originally thought that it should go at the bottom of the pokedex page, but had some problems with the new entry divs covering it up. Made me wonder if we want this to be styled like the buttons or if we want it to be a link like on the choose starter page. What do you think?

If you do think it should go on the bottom of the page, we can play around with the CSS and make sure the entries don't cover it up.
