### PR TITLE
Remove display block styling from #quit links

### DIFF
--- a/app/assets/stylesheets/_starter.scss
+++ b/app/assets/stylesheets/_starter.scss
@@ -21,6 +21,5 @@
     font: bold 1.25em 'Share Tech Mono';
     color: black;
     margin-top: 40px;
-    display: block;
   }
 }


### PR DESCRIPTION
The links were styled with display: block, so it was taking up the full width of the line. Removed the display property from the styling.
