### PR TITLE
Release pokemon

### DIFF
--- a/app/assets/stylesheets/_pokedex.scss
+++ b/app/assets/stylesheets/_pokedex.scss
@@ -77,4 +77,9 @@ img.pokedex-img {
   margin-left: auto;
   margin-right: auto;
   padding: 10px;
+  padding-bottom: 0px;
+}
+a.release-pokemon {
+  font-family: $game-font;
+  color: #fff;
 }

--- a/app/controllers/pocket_monsters_controller.rb
+++ b/app/controllers/pocket_monsters_controller.rb
@@ -20,4 +20,9 @@ class PocketMonstersController < ApplicationController
       redirect_to trainer_pocket_monsters_path(params[:trainer_id])
     end
   end
+
+  def destroy
+    PocketMonster.find(params[:id]).destroy
+    redirect_to trainer_pocket_monsters_path(params[:trainer_id])
+  end
 end

--- a/app/views/pocket_monsters/_pokedex_entry.html.erb
+++ b/app/views/pocket_monsters/_pokedex_entry.html.erb
@@ -2,4 +2,5 @@
   <% pokemon_name = PokemonEntry.find(pokemon.species_id).species_name %>
   <div class="entry-header"><h2>No. <%= pokemon.species_id %> - <%= pokemon_name.capitalize %></h2></div>
   <%= image_tag("#{pokemon_name}.png", :alt => "#{pokemon_name}", :class => "pokedex-img") %>
+  <%= link_to "Release #{pokemon_name.capitalize}", trainer_pocket_monster_path(id: pokemon.id, trainer_id: pokemon.trainer_id), method: :delete, data: { confirm: "Are you sure you want to release #{pokemon_name.capitalize} and remove it from your Pokedex?" } %>
 </div>

--- a/app/views/pocket_monsters/_pokedex_entry.html.erb
+++ b/app/views/pocket_monsters/_pokedex_entry.html.erb
@@ -2,5 +2,5 @@
   <% pokemon_name = PokemonEntry.find(pokemon.species_id).species_name %>
   <div class="entry-header"><h2>No. <%= pokemon.species_id %> - <%= pokemon_name.capitalize %></h2></div>
   <%= image_tag("#{pokemon_name}.png", :alt => "#{pokemon_name}", :class => "pokedex-img") %>
-  <%= link_to "Release #{pokemon_name.capitalize}", trainer_pocket_monster_path(id: pokemon.id, trainer_id: pokemon.trainer_id), method: :delete, data: { confirm: "Are you sure you want to release #{pokemon_name.capitalize} and remove it from your Pokedex?" } %>
+  <%= link_to "Release #{pokemon_name.capitalize}", trainer_pocket_monster_path(id: pokemon.id, trainer_id: pokemon.trainer_id), method: :delete, data: { confirm: "Are you sure you want to release #{pokemon_name.capitalize} and remove it from your Pokedex?" }, class: "release-pokemon" %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Pokedex::Application.routes.draw do
 
   resources :trainers do
     get :choose_starter
-    resources :pocket_monsters, only: [:index, :create] do
+    resources :pocket_monsters, only: [:index, :create, :destroy] do
       post :starter
     end
   end

--- a/spec/controllers/pocket_monsters_controller_spec.rb
+++ b/spec/controllers/pocket_monsters_controller_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe PocketMonstersController do
   let!(:trainer) { Trainer.create(name: "Gary") }
+  let!(:pokemon) { PocketMonster.create(trainer_id: trainer.id, species_id: 1)}
 
   it "#index" do
     get :index, trainer_id: trainer.id
@@ -12,5 +13,11 @@ describe PocketMonstersController do
     expect {
       post :create, trainer_id: trainer.id, species_id: 1
     }.to change { trainer.pocket_monsters.count }.by(1)
+  end
+
+  it "#destroy" do
+    expect {
+      delete :destroy, trainer_id: pokemon.trainer_id, id: pokemon.id
+    }.to change { trainer.pocket_monsters.count }.by(-1)
   end
 end

--- a/spec/features/release_pokemon_spec.rb
+++ b/spec/features/release_pokemon_spec.rb
@@ -17,4 +17,12 @@ feature "Trainer can 'release' (delete) a Pokemon" do
     page.driver.browser.switch_to.alert.dismiss
     expect(page).to have_content("Bulbasaur")
   end
+
+  scenario "trainer only releases 1 Pokemon when they have duplicates", js: true do
+    PocketMonster.create(trainer_id: trainer.id, species_id: 1)
+    visit trainer_pocket_monsters_path(trainer.id)
+    first(:link, "Release Bulbasaur").click
+    page.driver.browser.switch_to.alert.accept
+    expect(page).to have_content("No. 1 - Bulbasaur", :count => 1)
+  end
 end

--- a/spec/features/release_pokemon_spec.rb
+++ b/spec/features/release_pokemon_spec.rb
@@ -10,4 +10,11 @@ feature "Trainer can 'release' (delete) a Pokemon" do
     page.driver.browser.switch_to.alert.accept
     expect(page).to have_no_content("Bulbasaur")
   end
+
+  scenario "trainer clicks 'Release Pokemon' link and denies release", js: true do
+    visit trainer_pocket_monsters_path(trainer.id)
+    click_link("Release Bulbasaur")
+    page.driver.browser.switch_to.alert.dismiss
+    expect(page).to have_content("Bulbasaur")
+  end
 end

--- a/spec/features/release_pokemon_spec.rb
+++ b/spec/features/release_pokemon_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+feature "Trainer can 'release' (delete) a Pokemon" do
+  let!(:trainer) {Trainer.create(name: "Gary")}
+  let!(:pokemon) {PocketMonster.create(trainer_id: trainer.id, species_id: 1)}
+
+  scenario "trainer clicks 'Release Pokemon' link and confirms release", js: true do
+    visit trainer_pocket_monsters_path(trainer.id)
+    click_link("Release Bulbasaur")
+    page.driver.browser.switch_to.alert.accept
+    expect(page).to have_no_content("Bulbasaur")
+  end
+end


### PR DESCRIPTION
This pull request adds the feature to "release" (delete) a Pokemon from your Pokedex. For now I added the release link under the Pokemon image. Was able to keep same size .pokedex-entry divs by removing padding under Pokemon image. I know we discussed potentially adding this link into the modal, but wanted to discuss how we want to go about doing that.
